### PR TITLE
Update README to add double quotes around package names in dependencies ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ It's quite simple to add a dependency. Simply add it to your `Nut.toml` file:
 ```toml
 [dependencies]
 
-github.com/octokit/go-octokit/octokit = ""
-github.com/fhs/go-netrc/netrc = "4422b68c9c"
+"github.com/octokit/go-octokit/octokit" = ""
+"github.com/fhs/go-netrc/netrc" = "4422b68c9c"
 ```
 
 The format of declaring a dependency is `PACKAGE = COMMIT-ISH`.


### PR DESCRIPTION
...example as not doing so causes an issue when parsing the TOML file

I'm not sure if this is a recent change but when I setup a new nut project I got this error:

```
Near line 7 (last key parsed 'dependencies'): Bare keys cannot contain '.'.
```
