### PR TITLE
Fixed version locking problems

### DIFF
--- a/download.go
+++ b/download.go
@@ -7,6 +7,7 @@ import (
 )
 
 func downloadPkgs(deps ManifestDeps) error {
+	srcPath := getSrcPath(setting.WorkDir())
 	for importPath, rev := range deps {
 		showRev := rev
 		if showRev == "" {
@@ -14,7 +15,7 @@ func downloadPkgs(deps ManifestDeps) error {
 		}
 
 		fmt.Printf("Downloading %s@%s\n", importPath, showRev)
-		err := downloadPkg(setting.WorkDir(), importPath, rev)
+		err := downloadPkg(srcPath, importPath, rev)
 		if err != nil {
 			return err
 		}
@@ -43,4 +44,8 @@ func downloadPkg(dir, importPath, rev string) error {
 	}
 
 	return nil
+}
+
+func getSrcPath(path string) string {
+	return path + "/src"
 }


### PR DESCRIPTION
This is following #16, which is that the repository version is ignored and is used master revision.

This PR resolve this issues to
- Modified download path from "$workdir" to "$workdir/src" 

Original ver works as downloading repos and changing revision, but next `go get` downloads new latest one.
This change works as downloading repos and changing revision, and next `go get` uses the downloaded cache.
