### PR TITLE
Added all subdirectories of importPaths for rewrite

### DIFF
--- a/download.go
+++ b/download.go
@@ -45,7 +45,3 @@ func downloadPkg(dir, importPath, rev string) error {
 
 	return nil
 }
-
-func getSrcPath(path string) string {
-	return path + "/src"
-}

--- a/install.go
+++ b/install.go
@@ -34,10 +34,11 @@ func runInstall(c *cli.Context) {
 		importPaths = append(importPaths, importPath)
 	}
 
+	importPathDirs := getAllDeepPaths(importPaths)
 	pl := &PkgLoader{
 		GoPath: setting.WorkDir(),
 	}
-	pkgs, err := pl.Load(importPaths...)
+	pkgs, err := pl.Load(importPathDirs...)
 	check(err)
 
 	p, err := NewProject()

--- a/path.go
+++ b/path.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func getAllDeepPaths(importPaths []string) []string {
+	var importPathDirs []string
+	for _, path := range importPaths {
+		dirs, err := getDeepPaths(path)
+		check(err)
+		importPathDirs = append(importPathDirs, dirs...)
+	}
+	return importPathDirs
+}
+
+func getDeepPaths(importPath string) ([]string, error) {
+	rootPath := renameToAbsPath(importPath)
+	var dirs []string
+	walkFn := func(path string, info os.FileInfo, err error) error {
+		if isIgnoreName(rootPath, path) {
+			return nil
+		}
+		stat, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		if !stat.IsDir() {
+			return nil
+		}
+		path = renameToImportPath(path)
+		dirs = append(dirs, path)
+		return nil
+	}
+	err := filepath.Walk(rootPath, walkFn)
+	if err != nil {
+		return dirs, err
+	}
+	return dirs, nil
+}
+
+func isIgnoreName(root, path string) bool {
+	// check first string
+	path = strings.Replace(path, root+"/", "", 1)
+	for _, r := range path {
+		s := string(r)
+		if s == "." || s == "_" {
+			return true
+		}
+		break
+	}
+	return false
+}
+
+func renameToAbsPath(path string) string {
+	return getSrcPath(setting.WorkDir()) + "/" + path
+}
+
+func renameToImportPath(path string) string {
+	return strings.Replace(path, getSrcPath(setting.WorkDir())+"/", "", 1)
+}
+
+func getSrcPath(path string) string {
+	return path + "/src"
+}

--- a/path_test.go
+++ b/path_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TODO: add TestGetAllDeepPaths
+
+func TestGetDeepPaths(t *testing.T) {
+	gopath := setting.WorkDir()
+	importPath := "github.com/jingweno/nut"
+	absPath := gopath + "/src/" + importPath
+	examplePath := absPath + "/example"
+
+	makeDir(examplePath, "test1/test5/test6")
+	makeDir(examplePath, "test1/test5/test7")
+	makeDir(examplePath, "test1/test5/test8")
+	makeDir(examplePath, "test2")
+	makeDir(examplePath, "test3/test4")
+
+	paths, err := getDeepPaths(importPath)
+	if err != nil {
+		t.Fatalf("err must be nil, actual=%s", err.Error())
+	}
+
+	pathMap := make(map[string]bool)
+	for _, path := range paths {
+		pathMap[path] = true
+	}
+
+	expects := []string{
+		importPath,
+		importPath + "/example",
+		importPath + "/example/test1",
+		importPath + "/example/test2",
+		importPath + "/example/test3",
+		importPath + "/example/test3/test4",
+		importPath + "/example/test1/test5",
+		importPath + "/example/test1/test5/test6",
+		importPath + "/example/test1/test5/test7",
+		importPath + "/example/test1/test5/test8",
+	}
+
+	if len(paths) != len(expects) {
+		t.Fatalf("paths must have [%d] slice, actual=%v", len(expects), paths)
+	}
+
+	for _, expect := range expects {
+		if _, ok := pathMap[expect]; !ok {
+			t.Fatalf("paths must contain %s, paths=%v", expect, pathMap)
+		}
+	}
+}
+
+func makeDir(path, dir string) {
+	os.MkdirAll(path+"/"+dir, 0775)
+}
+
+func TestIsIgnoreName(t *testing.T) {
+	gopath := "/tmp/example/gopath"
+	importPath := "github.com/jingweno/nut"
+	absPath := gopath + "/src/" + importPath
+
+	normalDir := absPath + "/myProject"
+	if isIgnoreName(absPath, normalDir) == true {
+		t.Fatalf("normalDir must not be ignored dir, normalDir=%s", normalDir)
+	}
+
+	gitDir := absPath + "/.git"
+	if isIgnoreName(absPath, gitDir) != true {
+		t.Fatalf("gitDir must be ignored dir, gitDir=%s", gitDir)
+	}
+
+	underScoreDir := absPath + "/_vendor"
+	if isIgnoreName(absPath, underScoreDir) != true {
+		t.Fatalf("underScoreDir must be ignored dir, underScoreDir=%s", underScoreDir)
+	}
+}
+
+func TestRenameToAbsPath(t *testing.T) {
+	importPath := "github.com/jingweno/nut"
+	gopath := setting.WorkDir()
+	renamedPath := renameToAbsPath(importPath)
+
+	absPath := gopath + "/src/" + importPath
+	if renamedPath != absPath {
+		t.Fatalf("renamedPath must be %s, actual=%s", absPath, renamedPath)
+	}
+}
+
+func TestRenameToImportPath(t *testing.T) {
+	importPath := "github.com/jingweno/nut"
+	gopath := setting.WorkDir()
+	absPath := gopath + "/src/" + importPath
+	renamedPath := renameToImportPath(absPath)
+	if renamedPath != importPath {
+		t.Fatalf("renamedPath must be %s, actual=%s", importPath, renamedPath)
+	}
+}
+
+func TestGetSrcPath(t *testing.T) {
+	gopath := "/tmp/example/gopath"
+	srcPath := getSrcPath(gopath)
+	if srcPath != "/tmp/example/gopath/src" {
+		t.Fatalf("srcPath must be %s/src, actual=%s", gopath, srcPath)
+	}
+}


### PR DESCRIPTION
## problem

This fixes #19, which is rewriting import path problems of subdirectories 
when the repository does not have any go files
## reproduce step

Add any repository, which have isolated sub directory package, to Nut.toml.

Nut.toml

``` toml
[dependencies]

"github.com/awslabs/aws-sdk-go" = "8753e85c61243cf9c31ac5cafa6596dfc77d2a24"
```

install and check.

``` sh
$ nut install
Downloading github.com/awslabs/aws-sdk-go@8753e85c61243cf9c31ac5cafa6596dfc77d2a24
Vendoring dependencies

$ find vendor -type f -name "*.go"|xargs grep "github.com/awslabs/aws-sdk-go" | head
vendor/_nuts/github.com/awslabs/aws-sdk-go/aws/param_validator_test.go: "github.com/awslabs/aws-sdk-go/aws"
vendor/_nuts/github.com/awslabs/aws-sdk-go/aws/service.go:  "github.com/awslabs/aws-sdk-go/internal/endpoints"
...
...
```

It shows that import paths are pristine and not rewritten for nut.
## test steps

prepare this commit,

``` bash
$ git remote add pr git@github.com:evalphobia/nut.git
$ git fetch pr
$ git checkout -b issues/19 pr/issues/19
```

Install and check.

install and check.

``` sh
$ nut install
Downloading github.com/awslabs/aws-sdk-go@8753e85c61243cf9c31ac5cafa6596dfc77d2a24
Vendoring dependencies

$ find vendor -type f -name "*.go"|xargs grep "github.com/awslabs/aws-sdk-go" | head
vendor/_nuts/github.com/awslabs/aws-sdk-go/aws/param_validator_test.go: "github.com/foobar/nut-test/vendor/_nuts/github.com/awslabs/aws-sdk-go/aws"
vendor/_nuts/github.com/awslabs/aws-sdk-go/aws/service.go:  "github.com/foobar/nut-test/vendor/_nuts/github.com/awslabs/aws-sdk-go/internal/endpoints"
...
...
```

It shows that import paths are rewritten for nut, 
username=`foobar`, reponame=`nut-test`
