### PR TITLE
update github.com URL of nut (s/gophergala/jingweno/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Make sure you have a working Go environment. [See the install instructions](http
 
 To install `nut`, simply run:
 ```
-$ go get github.com/gophergala/nut
+$ go get github.com/jingweno/nut
 ```
 
 Make sure your `PATH` includes to the `$GOPATH/bin` directory so your
@@ -158,7 +158,7 @@ Besides, `nut`'s design philosophy is very different from `godep`:
 
 ## Who is using `nut`?
 
-* [nut](https://github.com/gophergala/nut)
+* [nut](https://github.com/jingweno/nut)
 * [hub](https://github.com/github/hub) (WIP)
 
 ## Other arts


### PR DESCRIPTION
change of URL in README.md

Not sure if the "Voting for nut" section is still relevant since votes were accepted only until end of January, 2015 - maybe it could be removed as well?
