### PR TITLE
Modified importPaths to add subdirectories

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -231,6 +231,7 @@ func listPkgs(name ...string) ([]*pkg, error) {
 	l := pkgLister{
 		Env: goCmdEnv(),
 	}
+	name = addSubPaths(name)
 	return l.List(name...)
 }
 
@@ -276,4 +277,16 @@ func (l *pkgLister) List(name ...string) (a []*pkg, err error) {
 	}
 
 	return a, nil
+}
+
+func addSubPaths(name []string) []string {
+	var paths []string
+	for _, path := range name {
+		paths = append(paths, addSubPath(path))
+	}
+	return paths
+}
+
+func addSubPath(path string) string {
+	return path + "/..."
 }


### PR DESCRIPTION
This pr is rewrote of #20, using `go list`. 

---
## problem

This fixes #19, which is rewriting import path problems of subdirectories 
when the repository does not have any go files
## reproduce step

Add any repository, which have isolated sub directory package, to Nut.toml.

Nut.toml

``` toml
[dependencies]

"github.com/awslabs/aws-sdk-go" = "8753e85c61243cf9c31ac5cafa6596dfc77d2a24"
```

install and check.

``` sh
$ nut install
Downloading github.com/awslabs/aws-sdk-go@8753e85c61243cf9c31ac5cafa6596dfc77d2a24
Vendoring dependencies

$ find vendor -type f -name "*.go"|xargs grep "github.com/awslabs/aws-sdk-go" | head
vendor/_nuts/github.com/awslabs/aws-sdk-go/aws/param_validator_test.go: "github.com/awslabs/aws-sdk-go/aws"
vendor/_nuts/github.com/awslabs/aws-sdk-go/aws/service.go:  "github.com/awslabs/aws-sdk-go/internal/endpoints"
...
...
```

It shows that import paths are pristine and not rewritten for nut.
## test steps

prepare this commit,

``` bash
$ git remote add pr git@github.com:evalphobia/nut.git
$ git fetch pr
$ git checkout -b issues/19 pr/issues/19
```

Install and check.

install and check.

``` sh
$ nut install
Downloading github.com/awslabs/aws-sdk-go@8753e85c61243cf9c31ac5cafa6596dfc77d2a24
Vendoring dependencies

$ find vendor -type f -name "*.go"|xargs grep "github.com/awslabs/aws-sdk-go" | head
vendor/_nuts/github.com/awslabs/aws-sdk-go/aws/param_validator_test.go: "github.com/foobar/nut-test/vendor/_nuts/github.com/awslabs/aws-sdk-go/aws"
vendor/_nuts/github.com/awslabs/aws-sdk-go/aws/service.go:  "github.com/foobar/nut-test/vendor/_nuts/github.com/awslabs/aws-sdk-go/internal/endpoints"
...
...
```

It shows that import paths are rewritten for nut, 
username=`foobar`, reponame=`nut-test`
